### PR TITLE
Modify key generation algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ composer require fuwasegu/cache-decorator
 > [!CAUTION]
 > Since serialization costs can be high, caching should primarily be applied to I/O bottleneck scenarios, 
 > such as HTTP communication and relational database interactions. 
+> It is also useful for computationally expensive algorithms (e.g., full search).
 > 
 > Moreover, the caching driver should utilize lighter options like Redis or Memcached instead of relying on the heavier I/O operations to achieve expected performance improvements.
 

--- a/src/CacheDecorator.php
+++ b/src/CacheDecorator.php
@@ -96,11 +96,7 @@ class CacheDecorator
      */
     private function generateCacheKey(string $class, string $method, array $args): string
     {
-        if (false === $json = json_encode($args)) {
-            throw new LogicException('The arguments must be able to be encoded as JSON.');
-        }
-
-        return $class . $method . md5($json);
+        return $class . $method . sha1(serialize($args));
     }
 
     /**

--- a/tests/CacheDecoratorTest.php
+++ b/tests/CacheDecoratorTest.php
@@ -42,7 +42,7 @@ class CacheDecoratorTest extends TestCase
     #[Test]
     public function pureMethodIsCached(): void
     {
-        $key = Sample::class . 'sum' . md5((string)json_encode([2, 3]));
+        $key = $this->generateCacheKey(Sample::class, 'sum', [2, 3]);
 
         $this->cache
             ->expects($this->once())
@@ -63,7 +63,7 @@ class CacheDecoratorTest extends TestCase
     #[Test]
     public function pureMethodUsingCache(): void
     {
-        $key = Sample::class . 'sum' . md5((string)json_encode([2, 3]));
+        $key = $this->generateCacheKey(Sample::class, 'sum', [2, 3]);
 
         $this->cache
             ->expects($this->once())
@@ -83,7 +83,7 @@ class CacheDecoratorTest extends TestCase
     #[Test]
     public function pureMethodWithArrayArguments(): void
     {
-        $key = Sample::class . 'merge' . md5((string)json_encode([[1, 2], [3, 4]]));
+        $key = $this->generateCacheKey(Sample::class, 'merge', [[1, 2], [3, 4]]);
 
         $this->cache
             ->expects($this->once())
@@ -113,7 +113,7 @@ class CacheDecoratorTest extends TestCase
     #[Test]
     public function ttlSetting(): void
     {
-        $key = Sample::class . 'sum' . md5((string)json_encode([2, 3]));
+        $key = $this->generateCacheKey(Sample::class, 'sum', [2, 3]);
 
         $this->cache
             ->expects($this->once())
@@ -126,7 +126,7 @@ class CacheDecoratorTest extends TestCase
     #[Test]
     public function zeroTtlBypassesCache(): void
     {
-        $key = Sample::class . 'sum' . md5((string)json_encode([2, 3]));
+        $key = $this->generateCacheKey(Sample::class, 'sum', [2, 3]);
 
         $this->cache
             ->expects($this->once())
@@ -143,6 +143,14 @@ class CacheDecoratorTest extends TestCase
 
         $result = $this->decorator->ttl(0)->sum(2, 3);
         $this->assertEquals(5, $result);
+    }
+
+    /**
+     * @param array<int|string, mixed> $args
+     */
+    private function generateCacheKey(string $class, string $method, array $args): string
+    {
+        return $class . $method . sha1(serialize($args));
     }
 }
 


### PR DESCRIPTION
## before

- used `json_encode()` for serializing args
- used `md5()` for generating hash

## after

- use `serialize()` for serializing args
- use `sha1()` for generating hash